### PR TITLE
Fixing cmake to prevent linking error

### DIFF
--- a/detection/CMakeLists.txt
+++ b/detection/CMakeLists.txt
@@ -185,7 +185,7 @@ target_link_libraries( detection ${PROJECT_NAME}_lib)
 #   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 # )
 
-## Mark cpp header files for installation 
+## Mark cpp header files for installation
 # install(DIRECTORY include/${PROJECT_NAME}/
 #   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 #   FILES_MATCHING PATTERN "*.h"

--- a/detection/CMakeLists.txt
+++ b/detection/CMakeLists.txt
@@ -148,11 +148,11 @@ target_link_libraries(
 
 # Detection nodelet
 add_library( detection_nodelet src/detection_nodelet.cpp )
-target_link_libraries( detection_nodelet ${PROJECT_NAME}_lib helper)
+target_link_libraries( detection_nodelet ${PROJECT_NAME}_lib)
 
 # Detection node
 add_executable(detection src/detection_node.cpp)
-target_link_libraries( detection ${PROJECT_NAME}_lib helper)
+target_link_libraries( detection ${PROJECT_NAME}_lib)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -185,8 +185,7 @@ target_link_libraries( detection ${PROJECT_NAME}_lib helper)
 #   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 # )
 
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
+## Mark cpp header files for installation # install(DIRECTORY include/${PROJECT_NAME}/
 #   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 #   FILES_MATCHING PATTERN "*.h"
 #   PATTERN ".svn" EXCLUDE

--- a/detection/CMakeLists.txt
+++ b/detection/CMakeLists.txt
@@ -185,7 +185,8 @@ target_link_libraries( detection ${PROJECT_NAME}_lib)
 #   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 # )
 
-## Mark cpp header files for installation # install(DIRECTORY include/${PROJECT_NAME}/
+## Mark cpp header files for installation 
+# install(DIRECTORY include/${PROJECT_NAME}/
 #   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 #   FILES_MATCHING PATTERN "*.h"
 #   PATTERN ".svn" EXCLUDE

--- a/evaluation/CMakeLists.txt
+++ b/evaluation/CMakeLists.txt
@@ -148,11 +148,11 @@ target_link_libraries(
 
 # evaluation nodelet
 add_library( evaluation_nodelet src/evaluation_nodelet.cpp )
-target_link_libraries( evaluation_nodelet ${PROJECT_NAME}_lib helper)
+target_link_libraries( evaluation_nodelet ${PROJECT_NAME}_lib)
 
 # evaluation node
 add_executable(evaluation src/evaluation_node.cpp)
-target_link_libraries( evaluation ${PROJECT_NAME}_lib helper)
+target_link_libraries( evaluation ${PROJECT_NAME}_lib)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/sensor_processing/CMakeLists.txt
+++ b/sensor_processing/CMakeLists.txt
@@ -150,11 +150,11 @@ target_link_libraries(
 
 # Sensor setup nodelet
 add_library( sensor_setup_nodelet src/sensor_setup_nodelet.cpp )
-target_link_libraries( sensor_setup_nodelet ${PROJECT_NAME}_lib helper)
+target_link_libraries( sensor_setup_nodelet ${PROJECT_NAME}_lib)
 
 # Sensor setup node
 add_executable(sensor_setup src/sensor_setup_node.cpp)
-target_link_libraries( sensor_setup ${PROJECT_NAME}_lib helper)
+target_link_libraries( sensor_setup ${PROJECT_NAME}_lib)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/tracking/CMakeLists.txt
+++ b/tracking/CMakeLists.txt
@@ -148,11 +148,11 @@ target_link_libraries(
 
 # tracking nodelet
 add_library( tracking_nodelet src/tracking_nodelet.cpp )
-target_link_libraries( tracking_nodelet ${PROJECT_NAME}_lib helper)
+target_link_libraries( tracking_nodelet ${PROJECT_NAME}_lib)
 
 # tracking node
 add_executable(tracking src/tracking_node.cpp)
-target_link_libraries( tracking ${PROJECT_NAME}_lib helper)
+target_link_libraries( tracking ${PROJECT_NAME}_lib)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -149,11 +149,11 @@ target_link_libraries(
 
 # visualization nodelet
 add_library( visualization_nodelet src/visualization_nodelet.cpp )
-target_link_libraries( visualization_nodelet ${PROJECT_NAME}_lib helper)
+target_link_libraries( visualization_nodelet ${PROJECT_NAME}_lib)
 
 # visualization node
 add_executable(visualization src/visualization_node.cpp)
-target_link_libraries( visualization ${PROJECT_NAME}_lib helper)
+target_link_libraries( visualization ${PROJECT_NAME}_lib)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the


### PR DESCRIPTION
Small fix that allows to build the package. Deleting helper from target link libraries, probably, it should not be there.

Previously it was an error message like this: 
/usr/bin/ld: cannot find -lhelper
collect2: error: ld returned 1 exit status